### PR TITLE
build: refine vcpkg bootstrap

### DIFF
--- a/cmake/vcpkg/bootstrap/vcpkg_bootstrap.cmake
+++ b/cmake/vcpkg/bootstrap/vcpkg_bootstrap.cmake
@@ -22,17 +22,14 @@ endfunction()
 function(_vcpkg_checkout vcpkg_root vcpkg_ref)
   message(STATUS "vcpkg checkout to ${vcpkg_ref}")
 
-  if(EXISTS "${vcpkg_root}/.git/shallow")
-    message(WARNING "vcpkg is shallow, unshallowing...")
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} fetch --unshallow
-      WORKING_DIRECTORY ${vcpkg_root}
-      RESULT_VARIABLE result)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} fetch origin ${vcpkg_ref}
+    WORKING_DIRECTORY ${vcpkg_root}
+    RESULT_VARIABLE result)
 
-    if(NOT result EQUAL "0")
-      message(
-        FATAL_ERROR "${GIT_EXECUTABLE} fetch --unshallow failed with ${result}")
-    endif()
+  if(NOT result EQUAL "0")
+    message(
+      FATAL_ERROR "${GIT_EXECUTABLE} fetch ${vcpkg_ref} failed with ${result}")
   endif()
 
   execute_process(
@@ -50,7 +47,7 @@ endfunction()
 # clone
 function(_vcpkg_clone vcpkg_root vcpkg_repo vcpkg_ref)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} clone ${vcpkg_repo} ${vcpkg_root}
+    COMMAND ${GIT_EXECUTABLE} clone ${vcpkg_repo} ${vcpkg_root} --depth=1
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE result)
 

--- a/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
+++ b/cmake/vcpkg/bootstrap/vcpkg_load_triplet.cmake
@@ -185,7 +185,7 @@ endfunction()
 macro(_vcpkg_load_triplet)
   if(NOT DEFINED VCPKG_TARGET_TRIPLET)
     message(
-      WARNING
+      STATUS
         "VCPKG_TARGET_TRIPLET is not defined, detecting triplet from the system"
     )
 


### PR DESCRIPTION
- Fetch commit hash instead of unshallowing the full repo vcpkg.
- Suppress vcpkg triplet detection warning.